### PR TITLE
Try to inject webpack bundle result in a 404

### DIFF
--- a/EntryTokenParser.php
+++ b/EntryTokenParser.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace Fullpipe\Twig\Extension\Webpack;
+use Twig_Error_Loader;
+use Twig_Token;
 
 /**
  * EntryTokenParser.
@@ -34,7 +36,7 @@ class EntryTokenParser extends \Twig_TokenParser
      *
      * @param Twig_Token $token A Twig_Token instance
      *
-     * @return Twig_Node_Text
+     * @return \Twig_Node_Text
      *
      * @throws Twig_Error_Loader
      */
@@ -54,12 +56,12 @@ class EntryTokenParser extends \Twig_TokenParser
         if (isset($manifest[$entryName.'.js']) || isset($manifest[$entryName.'.css'])) {
             if (isset($manifest[$entryName.'.css'])) {
                 $entryPath = $this->publicPath.$manifest[$entryName.'.css'];
-                $assets[] = '<link rel="stylesheet" href="'.$entryPath.'">';
+                $assets[] = "/".$entryPath;
             }
 
             if (isset($manifest[$entryName.'.js'])) {
                 $entryPath = $this->publicPath.$manifest[$entryName.'.js'];
-                $assets[] = '<script type="text/javascript" src="'.$entryPath.'"></script>';
+                $assets[] = "/".$entryPath;
             }
         } else {
             throw new \Twig_Error_Loader('Webpack entry '.$entryName.' not exists.', $token->getLine(), $stream->getFilename());

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ services:
             - { name: twig.extension }
 ```
 
-### Inject entry points to your templates
+### Inject entry points to your templates just like assetic
 
 
-```twig (just like assetic)
+```
     <script type="text/javascript" src="{% webpack_entry 'vendor' %}"></script>
     <script type="text/javascript" src="{% webpack_entry 'main' %}"></script>
 ```

--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ services:
 
 ### Inject entry points to your templates
 
-```twig
-    {% webpack_entry 'vendor' %}
-    {% webpack_entry 'main' %}
+
+```twig (just like assetic)
+    <script type="text/javascript" src="{% webpack_entry 'vendor' %}"></script>
+    <script type="text/javascript" src="{% webpack_entry 'main' %}"></script>
 ```
 
 ### Others


### PR DESCRIPTION
When I've try to use your bundle to load javascript bundle, token is parsed with controllers context route (like route/edit/bundle.js for example) instead of producing relative path from web/, resulting in a 404. 
Parsing only the hashed file name and put it in href attribute is more familiar use (see asset function) and works perfectly.